### PR TITLE
Simple bug solution to the jest.config.js

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testURL: 'http://localhost:8000'
+};


### PR DESCRIPTION
I catch this error when try to run the test: (SecurityError: localStorage is not available for opaque origins)[https://github.com/facebook/jest/issues/6769] with the jest.config.js file